### PR TITLE
fix: redirect to video when clicking video thumbnail

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ This program was designed with the **Steam Deck** in mind. It features a "blinde
 
 ## [Watch the youtube tutorial video!](https://www.youtube.com/watch?v=VS80voWUoS8)
 
-<a href="https://www.youtube.com/watch?v=VS80voWUoS8">
+<a href="https://www.youtube.com/watch?v=VS80voWUoS8" target="_blank">
   <img src="https://i.imgur.com/SIypDNE.png" alt="Watch The Youtube video!" />
 </a>
 

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,9 @@ This program was designed with the **Steam Deck** in mind. It features a "blinde
 
 ## [Watch the youtube tutorial video!](https://www.youtube.com/watch?v=VS80voWUoS8)
 
-![Watch The Youtube video!](https://i.imgur.com/SIypDNE.png)
+<a href="https://www.youtube.com/watch?v=VS80voWUoS8">
+  <img src="https://i.imgur.com/SIypDNE.png" alt="Watch The Youtube video!" />
+</a>
 
 
 ## [Stop by the discord support server!](https://discord.gg/xSqWsARMMH)


### PR DESCRIPTION
I know this is an **extremely** small fix, but I fixed the thumbnail so it redirects to the YouTube tutorial instead of linking to the image.

I added `target="_blank"` as well but it seems like it doesn't work on GitHub.